### PR TITLE
Optimize vcov

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: csranks
 Type: Package
 Title: Confidence Sets for Ranks
-Version: 1.1.0.9000
+Version: 1.1.1.9000
 Authors@R: c(
     person("Daniel", "Wilhelm", ,"d.wilhelm@ucl.ac.uk", role = c("aut", "cre")),
     person("Pawel", "Morgen", ,"seriousmorgen@protonmail.com", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# csranks 1.1.1
+* Optimized `vcov.lmranks` method
+
 # csranks 1.1.0
 
 * Added `lmranks` function for linear modelling of ranks using single rank

--- a/tests/testthat/test_lmranks_vcov.R
+++ b/tests/testthat/test_lmranks_vcov.R
@@ -52,30 +52,68 @@ test_that("vcov works for singular model matrix, complete=FALSE", {
                c(3,3))
 })
 
+test_that("get_projection_residual_matrix works", {
+  X <- as.matrix(mtcars)
+  expected <- diag(1, nrow = ncol(X), ncol=ncol(X))
+  expected_resids <- matrix(nrow=nrow(X), ncol=ncol(X))
+  for(j in 1:ncol(X)){
+    X_minusj <- X[,-j]
+    Y <- X[,j]
+    m <- lm(Y~X_minusj-1)
+    
+    expected[-j,j] <- -coef(m)
+    expected_resids[,j] <- resid(m)
+  }
+  
+  object <- list(qr=qr(X))
+  actual <- get_projection_residual_matrix(object)
+  expect_equivalent(expected, actual)
+  expect_equivalent(expected_resids, X %*% actual)
+})
+
+test_that("get_projection_residual_matrix works for singular matrix", {
+  data(mtcars)
+  X <- as.matrix(mtcars[,-1])
+  X[,2] <- X[,1]
+  expected <- diag(1, nrow = ncol(X), ncol=ncol(X))
+  expected[2,-2] <- 0
+  expected[,2] <- NA
+  expected_resids <- matrix(nrow=nrow(X), ncol=ncol(X))
+  expected_resids[,2] <- NA
+  for(j in 1:ncol(X)){
+    if(j==2) next
+    X_minusj <- X[,-c(2,j)]
+    Y <- X[,j]
+    m <- lm(Y~X_minusj-1)
+    
+    expected[-c(2,j),j] <- -coef(m)
+    expected_resids[,j] <- resid(m)
+  }
+  
+  Y <- mtcars[,1]
+  object <- lm(Y~X-1)
+  actual <- get_projection_residual_matrix(object)
+  expect_equivalent(expected, actual)
+  expect_equivalent(expected_resids, X %*% actual)
+})
+
 test_that("get_and_separate_regressors works",{
   data(mtcars)
   model_1 <- lm(mpg ~ disp + cyl + hp, data=mtcars)
   model_1$rank_terms_indices <- 1
-  expected_W <- cbind(rep(1, nrow(mtcars)),
-                      as.matrix(mtcars[,c("cyl", "hp")]))
-  colnames(expected_W) <- c("(Intercept)", "cyl", "hp")
   expected_RX <- mtcars$disp
   names(expected_RX) <- rownames(mtcars)
   expected_out_1 <- list(RX = expected_RX,
-                         W = expected_W,
                          rank_column_index = 2) # Intercept
   expect_equal(get_and_separate_regressors(model_1),
                expected_out_1)
   
-  W <- as.matrix(mtcars[,c("cyl", "hp")])
   RX <- mtcars$disp
   Y <- mtcars$mpg
   model_2 <- lm(Y ~ W + RX)
   model_2$rank_terms_indices <- 2
   expected_out_2 <- expected_out_1
   names(expected_out_2$RX) <- 1:length(RX)
-  rownames(expected_out_2$W) <- 1:length(RX)
-  colnames(expected_out_2$W) <- c("(Intercept)", "Wcyl", "Whp")
   expected_out_2$rank_column_index <- 4
   expect_equal(get_and_separate_regressors(model_2),
                expected_out_2)
@@ -85,244 +123,101 @@ test_that("get_and_separate_regressors works for no ranked regressors",{
   model <- lm(mpg ~ disp + cyl + hp, data=mtcars)
   model$rank_terms_indices <- numeric(0)
   
-  expected_W <- cbind(rep(1, nrow(mtcars)),
-                      as.matrix(mtcars[,c("disp", "cyl", "hp")]))
-  colnames(expected_W) <- c("(Intercept)", "disp", "cyl", "hp")
   expected_out <- list(RX = integer(0),
-                       W = expected_W,
                        rank_column_index = integer(0))
   
   expect_equal(get_and_separate_regressors(model),
                expected_out)
 })
 
-test_that("get_projection_model works for ranked target", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(disp) + cyl + hp - 1, data=mtcars,
-                            omega = 1)
-  
-  RX <- original_model$model$`r(disp)`
-  names(RX) <- rownames(mtcars)
-  W <- as.matrix(mtcars[,c("cyl", "hp")])
-  expected_model <- lm(RX ~ W - 1)
-  expected_model$rank_terms_indices <- integer(0)
-  expected_model$ranked_response <- TRUE
-  expected_model$omega <- 1
-  
-  expect_equal(get_projection_model(original_model, 1),
-               expected_model)
-})
-
-test_that("get_projection_model works for usual target with ranked regressor present", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(disp) + cyl + hp - 1, data=mtcars,
-                            omega = 1)
-  
-  RX <- original_model$model$`r(disp)`
-  names(RX) <- rownames(mtcars)
-  W_l <- mtcars$cyl
-  names(W_l) <- rownames(mtcars)
-  W_minus_l <- as.matrix(mtcars[,"hp"])
-  colnames(W_minus_l) <- "hp"
-  rownames(W_minus_l) <- rownames(mtcars)
-  expected_model <- lm(W_l ~ RX + W_minus_l - 1)
-  expected_model$rank_terms_indices <- 1
-  expected_model$ranked_response <- FALSE
-  expected_model$omega <- 1
-  
-  expect_equal(get_projection_model(original_model, 2),
-               expected_model)
-})
-
-test_that("get_projection_model works for usual target with ranked regressor present", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(disp) + cyl + hp - 1, data=mtcars,
-                            omega = 1)
-  
-  RX <- original_model$model$`r(disp)`
-  names(RX) <- rownames(mtcars)
-  W_l <- mtcars$cyl
-  names(W_l) <- rownames(mtcars)
-  W_minus_l <- as.matrix(mtcars[,"hp"])
-  colnames(W_minus_l) <- "hp"
-  rownames(W_minus_l) <- rownames(mtcars)
-  expected_model <- lm(W_l ~ RX + W_minus_l - 1)
-  expected_model$rank_terms_indices <- 1
-  expected_model$ranked_response <- FALSE
-  expected_model$omega <- 1
-  
-  expect_equal(get_projection_model(original_model, 2),
-               expected_model)
-})
-
-test_that("get_projection_model works with no ranked regressors", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ disp + cyl + hp - 1, data=mtcars,
-                            omega=1)
-  
-  W_l <- mtcars$cyl
-  names(W_l) <- rownames(mtcars)
-  W_minus_l <- as.matrix(mtcars[,c("disp", "hp")])
-  colnames(W_minus_l) <- c("disp", "hp")
-  rownames(W_minus_l) <- rownames(mtcars)
-  expected_model <- lm(W_l ~ W_minus_l - 1)
-  expected_model$rank_terms_indices <- integer(0)
-  expected_model$ranked_response <- FALSE
-  expected_model$omega <- 1
-  
-  expect_equal(get_projection_model(original_model, 2),
-               expected_model)
-})
-
-test_that("get_projection_model works for intercept", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(disp) + cyl + hp, data=mtcars,
-                            omega=1)
-  
-  RX <- original_model$model$`r(disp)`
-  names(RX) <- rownames(mtcars)
-  W_l <- rep(1, nrow(mtcars))
-  names(W_l) <- rownames(mtcars)
-  W_minus_l <- as.matrix(mtcars[,c("cyl", "hp")])
-  expected_model <- lm(W_l ~ RX + W_minus_l - 1)
-  expected_model$rank_terms_indices <- 1
-  expected_model$ranked_response <- FALSE
-  expected_model$omega <- 1
-  
-  expect_equal(get_projection_model(original_model, 1),
-               expected_model)
-})
-
-test_that("get_projection_model works for model with 1 usual regressor", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(disp), data=mtcars,
-                            omega=1)
-  
-  RX <- original_model$model$`r(disp)`
-  names(RX) <- rownames(mtcars)
-  W_l <- rep(1, nrow(mtcars))
-  names(W_l) <- rownames(mtcars)
-  expected_model <- lm(W_l ~ RX - 1)
-  expected_model$rank_terms_indices <- 1
-  expected_model$ranked_response <- FALSE
-  expected_model$omega <- 1
-  
-  expect_equal(get_projection_model(original_model, 1),
-               expected_model)
-})
-
-test_that("calculate_g_l_3 works for no ranked regressors case", {
-  data(mtcars)
-  n_lequal_lesser_X <- NULL
-  W <- as.matrix(mtcars[, c("cyl", "hp")])
-  W <- cbind(rep(1, nrow(W)),
-             W)
-  
-  original_model <- lmranks(r(mpg) ~ cyl + hp, data=mtcars)
-  RY <- original_model$model$`r(mpg)`
-  W_l <- W[,2]
-  W_minus_l <- W[,-2]
-  proj_model <- lm(W_l ~ W_minus_l - 1)
-  proj_model$rank_terms_indices <- integer(0)
-  proj_model$ranked_response <- FALSE
-  
-  expected_out <- rep(0, nrow(mtcars))
-  
-  expect_equal(calculate_g_l_3(original_model, proj_model, n_lequal_lesser_X=n_lequal_lesser_X),
-               expected_out)
-})
-
-test_that("calculate_g_l_3 works for proj_model with ranked response", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(cyl) + hp, data=mtcars, omega=1)
-  RX <- original_model$model$`r(cyl)`
-  n_lequal_lesser_X <- count_lequal_lesser(mtcars$cyl, return_inverse_ranking = TRUE)
-  expected_I_X <- function(i,j) compare_for_tests(i,j,mtcars$cyl)
-  W <- as.matrix(mtcars[, c("hp")])
-  W <- cbind(rep(1, nrow(W)),
-             W)
-  
-  proj_model <- lm(RX ~ W - 1)
-  proj_model$rank_terms_indices <- integer(0)
-  proj_model$ranked_response <- TRUE
-  proj_model$omega <- 1
-  
-  original_resid <- resid(original_model)
-  predictor <- proj_model$fitted.values
-  
-  expected_out <- sapply(1:length(RX), function(i){
-    mean(
-      sapply(1:length(RX), function(j){
-        original_resid[j] * (expected_I_X(i,j) - predictor[j])
-      })
-    )
-  })
-  
-  expect_equal(calculate_g_l_3(original_model, proj_model, n_lequal_lesser_X=n_lequal_lesser_X),
-               expected_out)
-})
-
-test_that("calculate_g_l_3 works for proj_model with usual response", {
-  data(mtcars)
-  original_model <- lmranks(r(mpg) ~ r(cyl) + hp, data=mtcars, omega=1)
-  RX <- original_model$model$`r(cyl)`
-  n_lequal_lesser_X <- count_lequal_lesser(mtcars$cyl, return_inverse_ranking = TRUE)
-  expected_I_X <- function(i,j) compare_for_tests(i,j,mtcars$cyl)
-  W_l <- mtcars$hp
-  W_minus_l <- rep(1, length(W_l))
-  
-  
-  proj_model <- lm(W_l ~ RX + W_minus_l - 1)
-  proj_model$rank_terms_indices <- 1
-  proj_model$ranked_response <- FALSE
-  proj_model$omega <- 1
-  
-  original_resid <- resid(original_model)
-  coefs <- coef(proj_model)
-  proj_usual_predictor <- W_minus_l * coefs[2]
-  
-  expected_out <- sapply(1:length(RX), function(i){
-    mean(
-      sapply(1:length(RX), function(j){
-        original_resid[j] * (W_l[j] - coefs[1]*expected_I_X(i,j) - proj_usual_predictor[j])
-      })
-    )
-  })
-  
-  expect_equal(calculate_g_l_3(original_model, proj_model, n_lequal_lesser_X=n_lequal_lesser_X),
-               expected_out)
-})
-
-test_that("extract_nonrank_predictor works when no ranked regressors present", {
-  data(mtcars)
-  model <- lmranks(r(mpg) ~ cyl + disp, data=mtcars)
-  expected <- model$fitted.values
-  names(expected) <- NULL
-  expect_equal(extract_nonrank_predictor(model),
-               expected)
-})
-
-test_that("extract_nonrank_predictor works in singular case", {
-  data(mtcars)
-  mtcars$disp2 <- mtcars$disp
-  model <- lmranks(r(mpg) ~ disp + disp2, data=mtcars)
-  expected_nonrank_predictor <- coef(model)[1] + coef(model)[2] * mtcars$disp
-  expect_equal(extract_nonrank_predictor(model),
-               expected_nonrank_predictor)
-})
-
-test_that("extract_nonrank_predictor works when ranked regressors present", {
-  data(mtcars)
-  model <- lmranks(r(mpg) ~ r(cyl) + disp, data=mtcars)
-  expected_nonrank_predictor <- coef(model)[1] + coef(model)[3] * mtcars$disp
-  expect_equal(extract_nonrank_predictor(model),
-               expected_nonrank_predictor)
-})
+# test_that("calculate_g_l_3 works for no ranked regressors case", {
+#   data(mtcars)
+#   n_lequal_lesser_X <- NULL
+#   W <- as.matrix(mtcars[, c("cyl", "hp")])
+#   W <- cbind(rep(1, nrow(W)),
+#              W)
+#   
+#   original_model <- lmranks(r(mpg) ~ cyl + hp, data=mtcars)
+#   RY <- original_model$model$`r(mpg)`
+#   W_l <- W[,2]
+#   W_minus_l <- W[,-2]
+#   proj_model <- lm(W_l ~ W_minus_l - 1)
+#   proj_model$rank_terms_indices <- integer(0)
+#   proj_model$ranked_response <- FALSE
+#   
+#   expected_out <- rep(0, nrow(mtcars))
+#   
+#   expect_equal(calculate_g_l_3(original_model, proj_model, n_lequal_lesser_X=n_lequal_lesser_X),
+#                expected_out)
+# })
+# 
+# test_that("calculate_g_l_3 works for proj_model with ranked response", {
+#   data(mtcars)
+#   original_model <- lmranks(r(mpg) ~ r(cyl) + hp, data=mtcars, omega=1)
+#   RX <- original_model$model$`r(cyl)`
+#   n_lequal_lesser_X <- count_lequal_lesser(mtcars$cyl, return_inverse_ranking = TRUE)
+#   expected_I_X <- function(i,j) compare_for_tests(i,j,mtcars$cyl)
+#   W <- as.matrix(mtcars[, c("hp")])
+#   W <- cbind(rep(1, nrow(W)),
+#              W)
+#   
+#   proj_model <- lm(RX ~ W - 1)
+#   proj_model$rank_terms_indices <- integer(0)
+#   proj_model$ranked_response <- TRUE
+#   proj_model$omega <- 1
+#   
+#   original_resid <- resid(original_model)
+#   predictor <- proj_model$fitted.values
+#   
+#   expected_out <- sapply(1:length(RX), function(i){
+#     mean(
+#       sapply(1:length(RX), function(j){
+#         original_resid[j] * (expected_I_X(i,j) - predictor[j])
+#       })
+#     )
+#   })
+#   
+#   expect_equal(calculate_g_l_3(original_model, proj_model, n_lequal_lesser_X=n_lequal_lesser_X),
+#                expected_out)
+# })
+# 
+# test_that("calculate_g_l_3 works for proj_model with usual response", {
+#   data(mtcars)
+#   original_model <- lmranks(r(mpg) ~ r(cyl) + hp, data=mtcars, omega=1)
+#   RX <- original_model$model$`r(cyl)`
+#   n_lequal_lesser_X <- count_lequal_lesser(mtcars$cyl, return_inverse_ranking = TRUE)
+#   expected_I_X <- function(i,j) compare_for_tests(i,j,mtcars$cyl)
+#   W_l <- mtcars$hp
+#   W_minus_l <- rep(1, length(W_l))
+#   
+#   
+#   proj_model <- lm(W_l ~ RX + W_minus_l - 1)
+#   proj_model$rank_terms_indices <- 1
+#   proj_model$ranked_response <- FALSE
+#   proj_model$omega <- 1
+#   
+#   original_resid <- resid(original_model)
+#   coefs <- coef(proj_model)
+#   proj_usual_predictor <- W_minus_l * coefs[2]
+#   
+#   expected_out <- sapply(1:length(RX), function(i){
+#     mean(
+#       sapply(1:length(RX), function(j){
+#         original_resid[j] * (W_l[j] - coefs[1]*expected_I_X(i,j) - proj_usual_predictor[j])
+#       })
+#     )
+#   })
+#   
+#   expect_equal(calculate_g_l_3(original_model, proj_model, n_lequal_lesser_X=n_lequal_lesser_X),
+#                expected_out)
+# })
 
 test_that("get_ineq_indicator_function returns functions with identical arguments", {
   v <- 1:10
-  f1 <- get_ineq_indicator_function(FALSE, v)
-  f2 <- get_ineq_indicator_function(TRUE, v)
+  M <- matrix(v, nrow=1)
+  omega <- 0.5
+  f1 <- get_ineq_indicator_function(FALSE, M, omega, v)
+  f2 <- get_ineq_indicator_function(TRUE, M, omega, v)
   
   expect_equal(args(f1), args(f2))
 })
@@ -331,10 +226,12 @@ test_that("get_ineq_indicator_function remembers vector values across calls", {
   v1 <- 1:3
   v2 <- 4:6
   v3 <- 7:9
+  M <- matrix(v, nrow=1)
+  omega <- 0.5
   
-  f1 <- get_ineq_indicator_function(FALSE, v1)
-  f2 <- get_ineq_indicator_function(FALSE, v2)
-  f3 <- get_ineq_indicator_function(FALSE, v3)
+  f1 <- get_ineq_indicator_function(FALSE, M, omega, v1)
+  f2 <- get_ineq_indicator_function(FALSE, M, omega, v2)
+  f3 <- get_ineq_indicator_function(FALSE, M, omega, v3)
   
   expect_equal(f1(1,2,3), v1)
   expect_equal(f2(1,2,3), v2)
@@ -413,8 +310,8 @@ test_that("replace_ranks_with_ineq_indicator_and_calculate_residuals works
             predictor <- W %*% coefs
             expected_resid <- I_Y - predictor
             
-            expect_equal(replace_ranks_with_ineq_indicator_and_calculate_residuals(
-              original_model, nonrank_predictor = predictor, I_Y = I_Y
+            expect_equivalent(replace_ranks_with_ineq_indicator_and_calculate_residuals(
+              original_model, I_Y = I_Y
             ), expected_resid)
             
           })
@@ -440,8 +337,8 @@ test_that("replace_ranks_with_ineq_indicator_and_calculate_residuals works
             predictor <- W %*% coefs[-1]
             expected_resid <- I_Y - coefs[1] * I_X - predictor
             
-            expect_equal(replace_ranks_with_ineq_indicator_and_calculate_residuals(
-              original_model, nonrank_predictor = predictor, I_X = I_X, I_Y = I_Y
+            expect_equivalent(replace_ranks_with_ineq_indicator_and_calculate_residuals(
+              original_model, I_X = I_X, I_Y = I_Y
             ), expected_resid)
           })
 test_that("vcov produces correct asymptotic variance estimate of rank-rank slope with covariates present", {
@@ -458,33 +355,30 @@ test_that("vcov produces correct asymptotic variance estimate of rank-rank slope
 test_that("h1 works for ranked regressor with no covariates", {
   load(test_path("testdata", "lmranks_cov_sigmahat_covariates_FALSE.rda"))
   res <- lmranks(r(Y) ~ r(X))
-  proj_model <- get_projection_model(res, 2)
+  proj_residuals <- model.matrix(res) %*% get_projection_residual_matrix(res)
   
-  h1_lmranks <- calculate_g_l_1(res, proj_model)
-  expect_equal(h1_lmranks, h1)
+  h1_lmranks <- calculate_H2(res, proj_residuals)
+  expect_equal(h1_lmranks[,2], h1)
 })
 
 test_that("h2 works for ranked regressor with no covariates", {
   load(test_path("testdata", "lmranks_cov_sigmahat_covariates_FALSE.rda"))
   res <- lmranks(r(Y) ~ r(X))
-  proj_model <- get_projection_model(res, 2)
-  n_lequal_lesser_X <- count_lequal_lesser(X, return_inverse_ranking=TRUE)
-  n_lequal_lesser_Y <- count_lequal_lesser(Y, return_inverse_ranking=TRUE)
+  proj_residuals <- model.matrix(res) %*% get_projection_residual_matrix(res)
   
-  h2_lmranks <- calculate_g_l_2(res, proj_model, n_lequal_lesser_X=n_lequal_lesser_X,
-                                n_lequal_lesser_Y=n_lequal_lesser_Y)
-  expect_equal(h2_lmranks, h2)
+  h2_lmranks <- calculate_H2(res, proj_residuals)
+  expect_equal(h2_lmranks[,2], h2)
 })
 
 test_that("h3 works for ranked regressor with no covariates", {
   load(test_path("testdata", "lmranks_cov_sigmahat_covariates_FALSE.rda"))
   res <- lmranks(r(Y) ~ r(X))
-  proj_model <- get_projection_model(res, 2)
-  n_lequal_lesser_X <- count_lequal_lesser(X, return_inverse_ranking=TRUE)
+  proj_residual_matrix <- get_projection_residual_matrix(res)
+  H1 <- calculate_H1(res, model.matrix(res) %*% proj_residual_matrix)
+  H1_mean <- colMeans(H1)
+  h3_lmranks <- calculate_H3(res, proj_residual_matrix, H1_mean)
   
-  h3_lmranks <- calculate_g_l_3(res, proj_model, n_lequal_lesser_X=n_lequal_lesser_X)
-  
-  expect_equal(h3_lmranks, h3)
+  expect_equal(h3_lmranks[,2], h3)
 })
 
 test_that("vcov produces correct asymptotic variance estimate of rank-rank slope with no covariates", {
@@ -497,33 +391,30 @@ test_that("vcov produces correct asymptotic variance estimate of rank-rank slope
 test_that("h1 works for ranked regressor with covariates", {
   load(test_path("testdata", "lmranks_cov_sigmahat_covariates_TRUE.rda"))
   res <- lmranks(r(Y) ~ r(X) + W)
-  proj_model <- get_projection_model(res, 2)
+  proj_residuals <- model.matrix(res) %*% get_projection_residual_matrix(res)
   
-  h1_lmranks <- calculate_g_l_1(res, proj_model)
-  expect_equal(h1_lmranks, h1)
+  h1_lmranks <- calculate_H2(res, proj_residuals)
+  expect_equal(h1_lmranks[,2], h1)
 })
 
 test_that("h2 works for ranked regressor with covariates", {
   load(test_path("testdata", "lmranks_cov_sigmahat_covariates_TRUE.rda"))
   res <- lmranks(r(Y) ~ r(X)+W)
-  proj_model <- get_projection_model(res, 2)
-  n_lequal_lesser_X <- count_lequal_lesser(X, return_inverse_ranking=TRUE)
-  n_lequal_lesser_Y <- count_lequal_lesser(Y, return_inverse_ranking=TRUE)
+  proj_residuals <- model.matrix(res) %*% get_projection_residual_matrix(res)
   
-  h2_lmranks <- calculate_g_l_2(res, proj_model, n_lequal_lesser_X=n_lequal_lesser_X,
-                                n_lequal_lesser_Y=n_lequal_lesser_Y)
-  expect_equal(h2_lmranks, h2)
+  h2_lmranks <- calculate_H2(res, proj_residuals)
+  expect_equal(h2_lmranks[,2], h2)
 })
 
 test_that("h3 works for ranked regressor with covariates", {
   load(test_path("testdata", "lmranks_cov_sigmahat_covariates_TRUE.rda"))
   res <- lmranks(r(Y) ~ r(X)+W)
-  proj_model <- get_projection_model(res, 2)
-  n_lequal_lesser_X <- count_lequal_lesser(X, return_inverse_ranking=TRUE)
+  proj_residual_matrix <- get_projection_residual_matrix(res)
+  H1 <- calculate_H1(res, model.matrix(res) %*% proj_residual_matrix)
+  H1_mean <- colMeans(H1)
+  h3_lmranks <- calculate_H3(res, proj_residual_matrix, H1_mean)
   
-  h3_lmranks <- calculate_g_l_3(res, proj_model, n_lequal_lesser_X=n_lequal_lesser_X)
-  
-  expect_equal(h3_lmranks, h3)
+  expect_equal(h3_lmranks[,2], h3)
 })
 
 test_that("vcov produces correct asymptotic variance estimate of rank-rank slope with covariates", {


### PR DESCRIPTION
Covariance matrix now is estimated faster, both theoretically (O(n²p) - > O(np)) 
and practically (artificial example in tests takes 0.1 second instead of 15 seconds). Largely due to:

* Faster estimation of coefficients in projection models 
* Faster multiplication between indicator matrix and another, arbitrary

Naturally, code produces same results as before. 
#33 