### PR TITLE
hotfix when plot is used with non default indices

### DIFF
--- a/R/plotranking.R
+++ b/R/plotranking.R
@@ -51,6 +51,8 @@ plotranking <- function(ranks, L, U, popnames = NULL, title = NULL, subtitle = N
                          caption, colorbins, horizontal)
   cc <- scales::seq_gradient_pal("#66a182", "#d1495b", "Lab")(seq(0, 1, length.out = 4))
   p <- length(ranks)
+  max_rank <- max(U)
+  min_rank <- min(L)
   if (is.null(popnames)) popnames <- 1:p
   dat <- data.frame(ranks = ranks, L = L, U = U, popnames = popnames)
   coltitle <- ifelse(colorbins == 4, "quartile", "quantile bins")
@@ -86,7 +88,9 @@ plotranking <- function(ranks, L, U, popnames = NULL, title = NULL, subtitle = N
     pl <- pl + geom_errorbar(aes(xmin = L, xmax = U),
                   width = errorbar_width,
                   linewidth = 1, position = position_dodge(0.1)) + 
-      scale_x_continuous(limits = c(1, p), breaks = unique(c(1, seq(5, p, by = 5), p)), labels = unique(c(1, seq(5, p, by = 5), p)))
+      scale_x_continuous(limits = c(min_rank, max_rank), 
+                         breaks = unique(c(min_rank, seq(ceiling(min_rank / 5), max_rank, by = 5), max_rank)), 
+                         labels = unique(c(min_rank, seq(ceiling(min_rank / 5), max_rank, by = 5), max_rank)))
   }
     
   if (!horizontal) {

--- a/R/plotranking.R
+++ b/R/plotranking.R
@@ -89,8 +89,8 @@ plotranking <- function(ranks, L, U, popnames = NULL, title = NULL, subtitle = N
                   width = errorbar_width,
                   linewidth = 1, position = position_dodge(0.1)) + 
       scale_x_continuous(limits = c(min_rank, max_rank), 
-                         breaks = unique(c(min_rank, seq(ceiling(min_rank / 5), max_rank, by = 5), max_rank)), 
-                         labels = unique(c(min_rank, seq(ceiling(min_rank / 5), max_rank, by = 5), max_rank)))
+                         breaks = unique(c(min_rank, seq(ceiling(min_rank / 5)*5, max_rank, by = 5), max_rank)), 
+                         labels = unique(c(min_rank, seq(ceiling(min_rank / 5)*5, max_rank, by = 5), max_rank)))
   }
     
   if (!horizontal) {

--- a/tests/testthat/test_plotranking.R
+++ b/tests/testthat/test_plotranking.R
@@ -4,6 +4,7 @@ x <- seq(1, 3, length = n)
 sd <- diag(rep(0.04, n))
 ranks <- irank(x)
 CS <- csranks(x, sd)
+CS_ind <- csranks(x, sd, indices=c(3,5,6,7))
 popnames <- rev(LETTERS[1:n])
 
 test_that("default plotranking returns a ggplot object", {
@@ -35,4 +36,8 @@ test_that("default plotranking works for larger dataset", {
 
 test_that("S3 method for csranks works", {
   expect_s3_class(plot(CS), "ggplot")
+})
+
+test_that("S3 method for csranks with nondefault indices works", {
+  expect_s3_class(plot(CS_ind), "ggplot")
 })

--- a/tests/testthat/test_plotranking.R
+++ b/tests/testthat/test_plotranking.R
@@ -1,10 +1,10 @@
 # setup
 n <- 10 # not larger than 23
 x <- seq(1, 3, length = n)
-sd <- diag(rep(0.04, n))
+sd <- diag(rep(0.02, n))
 ranks <- irank(x)
 CS <- csranks(x, sd)
-CS_ind <- csranks(x, sd, indices=c(3,5,6,7))
+CS_ind <- csranks(x, sd, indices=c(5,6,7))
 popnames <- rev(LETTERS[1:n])
 
 test_that("default plotranking returns a ggplot object", {


### PR DESCRIPTION
plotranking implicitly assumed, that the observations passed are the whole population. Which is not the case, when user uses `csranks(..., indices=<custom-indices>)`. This fixes the behaviour.